### PR TITLE
Adding leef to output_format validation

### DIFF
--- a/src/cbc_syslog/cb_defense_syslog.py
+++ b/src/cbc_syslog/cb_defense_syslog.py
@@ -155,7 +155,7 @@ def verify_config_parse_servers():
 
     output_format = config.get('general', 'output_format').lower()
 
-    if not output_format == 'cef' and not output_format == 'json' and output_format == 'leef':
+    if not output_format == 'cef' and not output_format == 'json' and not output_format == 'leef':
         logger.error('invalid output_format type was specified')
         logger.error('Must specify JSON, CEF , or LEEF output format')
         logger.warn('Setting output format to CEF')


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] New and existing tests pass locally with the changes.
- [X] Code follows the style guidelines of this project (PEP8, clean code).
- [X] Linter has passed locally and any fixes were made for failures.
- [X] A self-review of the code has been done.

## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix


## What is the ticket or issue number?
<!-- Please link to a jira ticket or relevant issue. -->

- Ticket Number: N/A

- Issue Number: #43 

## Pull Request Description
Included `not` condition for allow `leef` as a valid `output_format`

## Does this introduce a breaking change?
- [X] No

## How Has This Been Tested?
Used `leef` as output_type in our configuration file, this change was necessary to pass the validation check
